### PR TITLE
add promises for mouse clicks

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@linthtml/linthtml": "^0.3.2",
     "@mate-academy/eslint-config": "*",
     "@mate-academy/linthtml-config": "0.0.1",
-    "@mate-academy/scripts": "^0.7.12",
+    "@mate-academy/scripts": "^1.5.0",
     "@mate-academy/stylelint-config": "0.0.9",
     "colors": "^1.3.3",
     "cypress": "^5.6.0",

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,7 @@
     <title>Promises practice</title>
     <link rel="stylesheet" href="./styles/main.scss">
   </head>
-  <body>
+  <body class = "root">
     <h1 class="logo">MA</h1>
     <script type="text/javascript" src="scripts/main.js"></script>
   </body>

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,1 +1,82 @@
 'use strict';
+
+const MOUSE_BUTTONS = {
+  0: 'left',
+  1: 'wheel',
+  2: 'right',
+};
+
+const body = document.querySelector('.root');
+
+const promiseOne = new Promise((resolve, reject) => {
+  body.addEventListener('mousedown', (clickEvent) => {
+    const { button } = clickEvent;
+
+    if (MOUSE_BUTTONS[button] === 'left'
+        || MOUSE_BUTTONS[button] === 'wheel'
+        || MOUSE_BUTTONS[button] === 'right'
+    ) {
+      resolve();
+    }
+  });
+
+  setTimeout(() => reject(new Error()), 3000);
+});
+
+promiseOne
+  .then(() =>
+    createNotification('success', 'First promise was resolved'))
+  .catch(() =>
+    createNotification('warning', 'First promise was rejected'));
+
+const promiseTwo = new Promise((resolve) => {
+  body.addEventListener('mousedown', (clickEvent) => {
+    const { button } = clickEvent;
+
+    if (MOUSE_BUTTONS[button] === 'left'
+        || MOUSE_BUTTONS[button] === 'right') {
+      resolve();
+    }
+  });
+});
+
+promiseTwo
+  .then(() =>
+    createNotification('success', 'Second promise was resolved'));
+
+const promiseThree = new Promise((resolve) => {
+  const buttonsClicked = {
+    'left': false,
+    'right': false,
+  };
+
+  body.addEventListener('mousedown', (clickEvent) => {
+    const { button } = clickEvent;
+
+    if (MOUSE_BUTTONS[button] === 'left') {
+      buttonsClicked.left = true;
+    }
+
+    if (MOUSE_BUTTONS[button] === 'right') {
+      buttonsClicked.right = true;
+    }
+
+    if (buttonsClicked.left && buttonsClicked.right) {
+      resolve();
+    }
+  });
+});
+
+promiseThree
+  .then(() =>
+    createNotification('success', 'Third promise was resolved'));
+
+function createNotification(type, message) {
+  const notification = document.createElement('div');
+
+  notification.textContent = message;
+  notification.classList.add('notification', type);
+  notification.dataset.qa = 'notification';
+
+  body.insertAdjacentElement('beforeend', notification);
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -22,3 +22,33 @@ body {
   align-items: center;
   justify-content: center;
 }
+
+.notification {
+  position: absolute;
+  top: 50px;
+  right: 50px;
+  padding: 25px;
+
+  width: 200px;
+
+  font-family: Verdana, sans-serif;
+  font-size: 18px;
+  font-weight: 500;
+  text-align: center;
+
+  border-radius: 15px;
+}
+
+@for $n from 1 to 5 {
+  .notification:nth-of-type(#{$n}) {
+    top: ($n - 1) * 100 + 20px;
+  }
+}
+
+.success {
+  background-color: rgba(230, 230, 0, 0.5);
+}
+
+.warning {
+  background-color: rgba(204, 51, 0, 0.5);
+}


### PR DESCRIPTION
Readme states: 
- The `firstPromise` should be
  - **resolved** with a message `First promise was resolved` on a **left** `click` in the `document`

Why do tests require first promise to be resolved on right and middle button clicks?

[DEMO LINK](https://dominosl.github.io/js_promises_practice_DOM/)